### PR TITLE
Release v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - You can see more about what's going on [here](https://github.com/leandrosimoes/project-urls-manager-vscode-extension/issues), even open a new issue with your sugestions/errors.
 
+
+## [1.2.2]
+### Changes
+- Add `package-lock.json` and `yarn.lock` files to be ignored into the default `ignorePaths` settings
+
+
 ## [1.2.1]
 ### Fixes
 - Fixed error on getting URLs on Mac OS

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "project-urls-manager",
 	"displayName": "Project URLs Manager",
 	"description": "Manage all urls of your project in one place",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"icon": "docs/icon-256.png",
 	"publisher": "Leandro",
 	"galleryBanner": {

--- a/src/services/configurations/index.ts
+++ b/src/services/configurations/index.ts
@@ -7,7 +7,15 @@ import { IConfigurations } from './interfaces'
 
 export const getConfigurations = async (): Promise<IConfigurations> => {
     const defaultResult = {
-        ignorePaths: ['node_modules,android,ios,.vscode,.git,.github'],
+        ignorePaths: [
+            'node_modules',
+            'android,ios',
+            '.vscode',
+            '.git',
+            '.github',
+            'package-lock.json',
+            'yarn.lock',
+        ],
         extensionsList: [
             '.js',
             '.jsx',
@@ -52,7 +60,9 @@ export const getConfigurations = async (): Promise<IConfigurations> => {
 
         return configurations
     } catch (error) {
-        logger.log({ message: `Error reading configurations: ${error.message}` })
+        logger.log({
+            message: `Error reading configurations: ${error.message}`,
+        })
         logger.log({
             message: `Using this default settings: ${JSON.stringify(defaultResult, null, 2)}`,
         })


### PR DESCRIPTION
### Changes
- Add `package-lock.json` and `yarn.lock` files to be ignored into the default `ignorePaths` settings